### PR TITLE
add note about arrow::open_dataset

### DIFF
--- a/book/lazy_execution.qmd
+++ b/book/lazy_execution.qmd
@@ -224,11 +224,12 @@ The `read_parquet()` method has not been implemented in the R Polars package, bu
 #| label: fight-eager-read-parquet
 #| message: false
 tic()
-arrow::read_parquet("Datasets/fakir_file.parquet") %>% 
+arrow::read_parquet("Datasets/fakir_file.parquet", as_data_frame = FALSE) %>% 
   filter(region == "Bretagne") %>% 
   group_by(departement,priority) %>% 
   summarise(mymean=mean(age, na.rm = TRUE)) %>% 
-  arrange(departement)
+  arrange(departement) %>%
+  collect()
 toc()
 ```
 
@@ -246,3 +247,22 @@ scan_parquet("Datasets/fakir_file.parquet")$
 toc()
 ```
 And it's another victory for the `lazy` execution!
+
+::: {.callout-important}
+
+Note that the {arrow} package also have ability to scan parquet files in a lazy way with the `arrow::open_dataset` function.
+
+```{r}
+#| label: fight-lazy-open-dataset
+#| message: false
+tic()
+arrow::open_dataset("Datasets/fakir_file.parquet") %>% 
+  filter(region == "Bretagne") %>% 
+  group_by(departement,priority) %>% 
+  summarise(mymean=mean(age, na.rm = TRUE)) %>% 
+  arrange(departement) %>%
+  collect()
+toc()
+```
+
+:::


### PR DESCRIPTION
Hi, thank you for creating this wonderful book!

I have two concerns about the "From a parquet file" section, which can be read as a comparison with the `arrow` package, and propose the following corrections.

- Use `as_data_frame = FALSE` in `arrow::read_parquet()`. If this is not used, Acero is not used and just an R DataFrame calculation is performed.
- Mention to `arrow::open_dataset()`. I think there is a risk of misleading people into thinking that the lazy scan functionality does not exist in the `arrow` package.