### PR TITLE
Revisit benchmark comparators

### DIFF
--- a/book/content/benchmarking/_from_csv.qmd
+++ b/book/content/benchmarking/_from_csv.qmd
@@ -183,6 +183,56 @@ toc()
 print(res_dplyr)
 ```
 
+## dplyr (Acero)
+
+```{r}
+#| label: csv-arrow-benchmarking
+
+csv_arrow <- function() {
+  
+  # Reading the csv file
+  result <- arrow::read_csv_arrow("Datasets/DataMultiTypes.csv", as_data_frame = FALSE)
+  
+  # Conversion of 2 columns to Date format
+  result <- result |>
+    mutate(
+      colDate1 = as.Date(colDate1),
+      colDate2 = as.Date(colDate2)
+    )
+  
+  # Creation of a diff column between 2 dates (in days)
+  result <- result |>
+    # difftime(unit = "days") is not supported in arrow yet
+    mutate(diff = round(as.integer64(difftime(colDate2, colDate1)) %/% (60 * 60 * 24), 0))
+  
+  # Filter rows
+  result <- result |>
+    filter(
+      colInt>2000 & colInt<8000
+      )
+  
+  # Grouping and aggregation
+  result_agg <- result |>
+    group_by(colString) |> 
+    summarise(
+      min_colInt = min(colInt),
+      mean_colInt = mean(colInt),
+      mas_colInt = max(colInt),
+      min_colNum = min(colNum),
+      mean_colNum = mean(colNum),
+      max_colNum = max(colNum)
+  ) |>
+    collect()
+
+  return(result_agg)
+}
+
+tic()
+res_arrow <- csv_arrow()
+toc()
+print(res_arrow)
+```
+
 ## data.table
 
 ```{r}
@@ -232,6 +282,7 @@ csv_bmk <- microbenchmark(
   #"polars (lazy) from csv file" = csv_lazy_polars()$collect(),
   "R base - from csv file" = csv_rbase(),
   "dplyr - from csv file" = csv_dplyr(),
+  "dplyr (Acero) - from csv file" = csv_arrow(),
   "data.table - from csv file" = as.data.frame(csv_dt()),
   times = 5
  )

--- a/book/content/benchmarking/_from_duckdb.qmd
+++ b/book/content/benchmarking/_from_duckdb.qmd
@@ -2,28 +2,31 @@
 
 ### Use DuckDB engine on R object
 
-Let's start by looking at how to use the DuckDb engine on R objects.  
-There are two main possibilities:  
+<!-- TODO: rewrite -->
+
+<!-- Let's start by looking at how to use the DuckDb engine on R objects.  
+There are two main possibilities:   -->
 
 
-1. To use the DuckDB engine to query a R object with **dplyr**, you can use the `arrow::to_duckdb()` method (**arrow/dplyr/DuckDB engine**) 
+<!-- 1. To use the DuckDB engine to query a R object with **dplyr**, you can use the `arrow::to_duckdb()` method (**arrow/dplyr/DuckDB engine**) 
 
 2. To use the DuckDB engine to query a R object with **the standard DBI methods**, you can use the `arrow::to_duckdb()` and `DBI::dbGetQuery()` methods (**arrow/SQL/DuckDB engine**).
-In the following example, we save the R data.frame as a DuckDb virtual table, giving it a name that will be used in the SQL query, finally we execute the query.
+In the following example, we save the R data.frame as a DuckDb virtual table, giving it a name that will be used in the SQL query, finally we execute the query. -->
 
 
 ::: {.panel-tabset}
 
-## arrow/dplyr/DuckDB
+## dplyr/DuckDB
 
 ```{r}
-#| label: duckdb-arrow-dplyr-benchmarking
+#| label: duckdb-dplyr-benchmarking
 
-duckdb_arrow_dplyr <- function(variables) {
-  
-  result <- DataMultiTypes |>
-    
-    to_duckdb() |>
+duckdb_dplyr <- function(variables) {
+  con <- DBI::dbConnect(duckdb::duckdb())
+
+  duckdb::duckdb_register(con, "DataMultiTypes", DataMultiTypes)
+
+  result <- tbl(con, "DataMultiTypes") |>
     
     mutate(
       # Conversion of 2 columns to Date format
@@ -43,29 +46,31 @@ duckdb_arrow_dplyr <- function(variables) {
       min_colNum = min(colNum, na.rm = TRUE),
       mean_colNum = mean(colNum, na.rm = TRUE),
       max_colNum = max(colNum, na.rm = TRUE)
-    )
+    ) |>
+    collect()
   
-  
+  DBI::dbDisconnect(con, shutdown=TRUE)
+
   return(result)
   
 }
 tic()
-duckdb_arrow_dplyr()
+duckdb_dplyr()
 toc()
 ```
 
 ## arrow/SQL/DuckDB
 
 ```{r}
-#| label: duckdb-arrow-sql-benchmarking
+#| label: duckdb-sql-benchmarking
 
-duckdb_arrow_sql <- function(variables) {
+duckdb_sql <- function(variables) {
   
-  con <- dbConnect(duckdb::duckdb())
-  
-  arrow::to_duckdb(DataMultiTypes, table_name = "DataMultiTypes_duckdb", con = con)
-  
-  result <- dbGetQuery(
+  con <- DBI::dbConnect(duckdb::duckdb())
+
+  duckdb::duckdb_register(con, "DataMultiTypes", DataMultiTypes)
+
+  result <- DBI::dbGetQuery(
     con, 
     "SELECT colString,
            MIN(colInt) AS min_colInt,
@@ -78,12 +83,12 @@ duckdb_arrow_sql <- function(variables) {
         SELECT colString,
                colInt,
                colNum
-        FROM DataMultiTypes_duckdb
+        FROM DataMultiTypes
         WHERE colInt > 2000 AND colInt < 8000
 ) AS filtered_data
 GROUP BY colString;")
   
-  dbDisconnect(con, shutdown=TRUE)
+  DBI::dbDisconnect(con, shutdown=TRUE)
   
   return(result)
   
@@ -111,8 +116,8 @@ One of the advantages of using the DuckDB engine and dplyr may be **to use a fea
 #| warning: false
 
 microbenchmark(
-  "arrow/dplyr/DuckDB" = duckdb_arrow_dplyr(),
-  "arrow/SQL/DuckDB" = duckdb_arrow_sql(),
+  "dplyr/DuckDB" = duckdb_dplyr(),
+  "SQL/DuckDB" = duckdb_sql(),
   times = 5
  )
 ```
@@ -127,12 +132,12 @@ For this comparison, we will use :
 
 ::: {.panel-tabset}
 
-## arrow/SQL
+## SQL
 
 ```{r}
-#| label: duckdb-sql-benchmarking
+#| label: duckdb-dbfile-sql-benchmarking
 
-duckdb_sql <- function(variables) {
+duckdb_dbfile_sql <- function(variables) {
   
   con <- dbConnect(duckdb::duckdb(),
                  "Datasets/DataMultiTypes.duckdb")
@@ -166,7 +171,7 @@ toc()
 ```
 :::
 
-### Results for partitioned parquet files
+### Results for DuckDB file
 
 ```{r}
 #| label: duckdb-results-benchmarking
@@ -174,7 +179,7 @@ toc()
 #| warning: false
 
 duckdb_bmk <- microbenchmark(
-  "SQL from duckdb file" = duckdb_sql(),
+  "SQL from duckdb file" = duckdb_dbfile_sql(),
   times = 5
  )
 duckdb_bmk

--- a/book/content/benchmarking/_from_duckdb.qmd
+++ b/book/content/benchmarking/_from_duckdb.qmd
@@ -2,17 +2,14 @@
 
 ### Use DuckDB engine on R object
 
-<!-- TODO: rewrite -->
+Let's start by looking at how to use the DuckDb engine on R objects.  
+There are 3 main possibilities:  
 
-<!-- Let's start by looking at how to use the DuckDb engine on R objects.  
-There are two main possibilities:   -->
+1. To use the DuckDB engine to query a R object with **dplyr**, you can use the `duckdb::duckdb_register()` method and then the `dplyr::tbl()` method to pass your dplyr instructions (**dplyr/DuckDB**). 
 
+2. To use the DuckDB engine to query a R object with **the standard DBI methods**, you can use the `duckdb::duckdb_register()` method and then the `DBI::dbGetQuery()` method to pass your SQL query (**SQL/DuckDB**).
 
-<!-- 1. To use the DuckDB engine to query a R object with **dplyr**, you can use the `arrow::to_duckdb()` method (**arrow/dplyr/DuckDB engine**) 
-
-2. To use the DuckDB engine to query a R object with **the standard DBI methods**, you can use the `arrow::to_duckdb()` and `DBI::dbGetQuery()` methods (**arrow/SQL/DuckDB engine**).
-In the following example, we save the R data.frame as a DuckDb virtual table, giving it a name that will be used in the SQL query, finally we execute the query. -->
-
+3. To use the DuckDB engine to query a R object in combination **with {arrow} package**, you can use the `arrow::to_duckdb()` and then pass your dplyr instructions (**dplyr/arrow/DuckDB**).
 
 ::: {.panel-tabset}
 
@@ -59,7 +56,7 @@ duckdb_dplyr()
 toc()
 ```
 
-## arrow/SQL/DuckDB
+## SQL/DuckDB
 
 ```{r}
 #| label: duckdb-sql-benchmarking
@@ -94,17 +91,54 @@ GROUP BY colString;")
   
 }
 tic()
-duckdb_arrow_sql()
+duckdb_sql()
+toc()
+```
+
+## arrow/dplyr/DuckDB
+
+```{r}
+#| label: duckdb-dplyr-benchmarking
+
+duckdb_arrow_dplyr <- function(variables) {
+          
+  result <- DataMultiTypes |>
+    
+    to_duckdb() |>
+    
+    mutate(
+      # Conversion of 2 columns to Date format
+      colDate1 = as.Date(colDate1),
+      colDate2 = as.Date(colDate2)
+    ) |>
+    # Filter rows
+    filter(
+      colInt>2000 & colInt<8000
+    ) |>
+    # Grouping and aggregation
+    group_by(colString) |> 
+    summarise(
+      min_colInt = min(colInt, na.rm = TRUE),
+      mean_colInt = mean(colInt, na.rm = TRUE),
+      mas_colInt = max(colInt, na.rm = TRUE),
+      min_colNum = min(colNum, na.rm = TRUE),
+      mean_colNum = mean(colNum, na.rm = TRUE),
+      max_colNum = max(colNum, na.rm = TRUE)
+    ) 
+  
+  return(result)
+  
+}
+tic()
+duckdb_arrow_dplyr()
 toc()
 ```
 :::
 
 ::: {.callout-tip}
-With the `arrow::to_duckdb()` method, we see that the result is returned by mentioning `#Database: DuckDB`, it is the DuckDB engine that was used.
-
 One of the advantages of using the DuckDB engine and dplyr may be **to use a feature implemented by DuckDB but not yet by Arrow**. We can do the opposite, and return to the Arrow engine with `arrow::to_arrow()`.
 
-**The interoperability between Arrow, DuckDB and dplyr is very easy to use and brings a lot of flexibility for data processing.**
+However, the benchmark results are clear: SQL queries are by far the fastest! 🏆
 :::
 
 
@@ -118,6 +152,7 @@ One of the advantages of using the DuckDB engine and dplyr may be **to use a fea
 microbenchmark(
   "dplyr/DuckDB" = duckdb_dplyr(),
   "SQL/DuckDB" = duckdb_sql(),
+  "dplyr/arrow/DuckDB" = duckdb_arrow_dplyr(),
   times = 5
  )
 ```
@@ -185,4 +220,4 @@ duckdb_bmk <- microbenchmark(
 duckdb_bmk
 ```
  
-Note that the query withthe standard DBI methods is faster than those with dplyr verbs 🏆
+Note that the query with the standard DBI methods is faster than those with dplyr verbs 🏆

--- a/book/content/benchmarking/_from_partitioned_parquet.qmd
+++ b/book/content/benchmarking/_from_partitioned_parquet.qmd
@@ -58,6 +58,44 @@ partitioned_parquet_arrow_lazy()
 toc()
 ```
 
+## dplyr (duckdb)
+
+```{r}
+#| label: partitioned-parquet-duckdb-benchmarking
+
+partitioned_parquet_duckdb <- function(variables) {
+  con <- DBI::dbConnect(duckdb::duckdb())
+  result <- tbl(con, "read_parquet('Datasets/DataMultiTypes/*/*.parquet', hive_partitioning=1)") |>
+    
+    mutate(
+      # Conversion of 2 columns to Date format
+      colDate1 = as.Date(colDate1),
+      colDate2 = as.Date(colDate2)
+    ) |>
+    # Filter rows
+    filter(
+      colInt>2000 & colInt<8000
+    ) |>
+    # Grouping and aggregation
+    group_by(colString) |> 
+    summarise(
+      min_colInt = min(colInt, na.rm = TRUE),
+      mean_colInt = mean(colInt, na.rm = TRUE),
+      mas_colInt = max(colInt, na.rm = TRUE),
+      min_colNum = min(colNum, na.rm = TRUE),
+      mean_colNum = mean(colNum, na.rm = TRUE),
+      max_colNum = max(colNum, na.rm = TRUE)
+    ) |> 
+    collect()
+  
+  DBI::dbDisconnect(con)
+  return(result)
+}
+tic()
+partitioned_parquet_duckdb() 
+toc()
+```
+
 ## polars (lazy)
 
 ```{r}

--- a/book/content/benchmarking/_from_partitioned_parquet.qmd
+++ b/book/content/benchmarking/_from_partitioned_parquet.qmd
@@ -13,6 +13,7 @@ fs::dir_tree(path = "Datasets/DataMultiTypes/")
 For this comparison, we will use :
 
 - For **arrow (lazy)**, the `arrow::open_dataset()` method
+- For **dplyr (duckdb)**, the ` DBI::dbConnect`, `dplyr::tbl()` and `arrow::read_parquet()` methods
 - For **polars (lazy)**, the `pl$scan_parquet()` method
 
 
@@ -63,8 +64,10 @@ toc()
 ```{r}
 #| label: partitioned-parquet-duckdb-benchmarking
 
-partitioned_parquet_duckdb <- function(variables) {
+partitioned_parquet_dplyr_duckdb <- function(variables) {
+  
   con <- DBI::dbConnect(duckdb::duckdb())
+  
   result <- tbl(con, "read_parquet('Datasets/DataMultiTypes/*/*.parquet', hive_partitioning=1)") |>
     
     mutate(
@@ -92,7 +95,7 @@ partitioned_parquet_duckdb <- function(variables) {
   return(result)
 }
 tic()
-partitioned_parquet_duckdb() 
+partitioned_parquet_dplyr_duckdb() 
 toc()
 ```
 
@@ -142,6 +145,7 @@ toc()
 
 partitioned_parquet_bmk <- microbenchmark(
   "arrow (lazy) - from partitioned parquet file" = partitioned_parquet_arrow_lazy(),
+  "dplyr (duckdb) - from partitioned parquet file" = partitioned_parquet_dplyr_duckdb(),
   "polars (lazy) - from partitioned parquet file" = partitioned_parquet_polars_lazy()$to_data_frame(),
   times = 5
  )


### PR DESCRIPTION
- `arrow::read_csv_arrow`
- `duckdb` supports hive partitioned Parquet datasets
- `duckdb` works perfectly well on its own and should not be represented as if it can only be used in combination with `arrow`.

Also, my understanding is that Polars does not support hive partitioned datasets (pola-rs/polars#4347).
During benchmarking it seems to be reading a single Parquet file, not a dataset.

I have only worked on the R code blocks for now, so if you would like to take over writing the text, that would be appreciated.